### PR TITLE
chore: migrate to Rust 1.95.0 and template base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable, beta, '1.89.0']  # 1.89.0 is our MSRV
+        rust: [stable, beta, '1.95.0']  # 1.95.0 is our MSRV
         include:
           - os: ubuntu-latest
             rust: nightly
@@ -133,6 +133,8 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
 
       - name: Check documentation
         run: cargo doc --no-deps --all-features --document-private-items
@@ -148,6 +150,8 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
@@ -163,6 +167,8 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
 
       - name: Run benchmarks
         run: cargo bench --no-run --all-features

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
 
       - name: Build
         run: cargo build --all-features

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
 
       - name: Build documentation
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,6 +42,8 @@ jobs:
       
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
       
       - name: Install cargo-supply-chain
         run: cargo install cargo-supply-chain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to `gguf_rs`! This document provides
 
 ### Prerequisites
 
-- Rust 1.70.0 or later
+- Rust 1.95.0 or later
 - Git
 - A GitHub account
 

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,8 @@ examples:
 
 # Check MSRV (Minimum Supported Rust Version)
 msrv:
-	@echo "Checking MSRV (1.89.0)..."
-	@cargo +1.89.0 check --all-features
+	@echo "Checking MSRV (1.95.0)..."
+	@cargo +1.95.0 check --all-features
 
 help:
 	@echo "Available targets:"

--- a/clippy.toml
+++ b/clippy.toml
@@ -44,4 +44,4 @@ future-size-threshold = 16384
 
 # Suppress specific lints that may not apply to this project
 # These can be uncommented and customized as needed
-# msrv = "1.70.0"  # Minimum supported Rust version
+# msrv = "1.95.0"  # Minimum supported Rust version


### PR DESCRIPTION
## Summary
- Bump project baseline to Rust 1.95.0.
- Update CI/tooling and Docker base image references to `docker.io/threatflux/rust-cicd-template:base-rust-latest` / `base-rust-1.95.0` patterns where applicable.
- Apply migration updates from `chore/rust-1.95-and-deps`.

This PR is part of the repository-wide ThreatFlux Rust toolchain migration.