### PR TITLE
ci: adopt ThreatFlux auto-release action

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,125 @@
+name: Auto Release
+
+concurrency:
+  group: auto-release-${{ github.event.workflow_run.head_branch || github.ref_name || 'main' }}
+  cancel-in-progress: true
+
+on:
+  workflow_run:
+    workflows: ["CI", "Security"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: Version bump type
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check for Release
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      should_release: ${{ steps.decide.outputs.should_release }}
+      target_sha: ${{ steps.target.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref_name }}
+
+      - name: Determine target SHA
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if [[ ! "${WORKFLOW_RUN_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Invalid workflow-run head SHA" >&2
+              exit 1
+            fi
+            echo "sha=${WORKFLOW_RUN_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check CI status
+        id: ci_status
+        run: |
+          TARGET_SHA="${{ steps.target.outputs.sha }}"
+          CI_STATUS=$(gh run list --workflow=ci.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          SECURITY_STATUS=$(gh run list --workflow=security.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          if [[ "$CI_STATUS" == "success" ]] && [[ "$SECURITY_STATUS" == "success" ]]; then
+            echo "all_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "all_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether to attempt a release
+        id: decide
+        env:
+          ALL_PASSED: ${{ steps.ci_status.outputs.all_passed }}
+        run: |
+          # The release action itself no-ops when no conventional commit
+          # warrants a release, so this gate only enforces green required runs.
+          if [[ "${ALL_PASSED}" == "true" ]]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Create Release
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ needs.check.outputs.target_sha }}
+
+      - name: Release
+        id: release
+        uses: ThreatFlux/github_actions/release@16d779cd569c34743eb6683ca4c0ce105e9ad234 # v0.4.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bump: ${{ github.event.inputs.version_bump || 'auto' }}
+
+      # Tags created with GITHUB_TOKEN do not trigger tag-push workflows, so
+      # dispatch the tag pipelines explicitly.
+      - name: Trigger tag pipelines
+        if: steps.release.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" -f version="$VERSION"


### PR DESCRIPTION
Adopts the ThreatFlux auto-release action for this repo via a new `.github/workflows/auto-release.yml`.

## What the action does

- On every push to `main` (once gated checks pass), the action inspects conventional-commit messages since the last tag, decides the semver bump, rewrites `Cargo.toml`/`Cargo.lock`, creates the tag, and publishes a GitHub Release — all through the GitHub API, with no git or cargo invocations at runtime.
- Merges containing only `chore:`/`docs:`/`ci:` style commits produce **no release** — the action no-ops when no commit warrants a bump. (This PR's own `ci:` commit will therefore not trigger a release.)
- A `workflow_dispatch` trigger allows manual runs with an explicit `patch`/`minor`/`major` bump override.

## Gating

The workflow runs on `workflow_run` completion of the **CI** and **Security** workflows for pushes to `main`, and double-checks via `gh run list` that both workflows concluded `success` for the exact target SHA before releasing.

## Tag-trigger limitation and dispatch chaining

Tags created with `GITHUB_TOKEN` do not trigger tag-push (`on: push: tags:`) workflows. To compensate, after a successful release the workflow explicitly dispatches the existing `release.yml` on the new tag with `-f version=<version>` (matching its required `version` input). There is no `docker.yml` in this repo, so no other pipeline is chained.

Two caveats worth knowing about the chained `release.yml` run:

- Its "Verify release provenance" step requires the tag to be an **annotated** tag object reachable from `origin/main`. If the auto-release action creates a lightweight tag via the API, that dispatched run will fail at the provenance check and the crates.io publish will not proceed.
- `release.yml` enforces that `gguf-rs-lib` and `gguf-cli` versions match. The action rewrites the root `Cargo.toml`; if `gguf-cli/Cargo.toml`'s version is not bumped in lockstep, the dispatched run will fail its version check.

Both failure modes are safe (the run refuses to publish); flagging them so a first release can be watched.

## release.yml / docker.yml bug fixes

None applied. The rollout checklist's suspected template bugs (a Windows "Build (native)" step missing `shell: bash`, a crates.io heredoc with an indented terminator, and a Windows packaging step missing its `.sha256` output) do not exist in this repo's `release.yml` — every step already declares `shell: bash`, the pipeline is ubuntu-only, and the crates.io check uses `jq` with no heredoc. There is no `docker.yml`.

## Pinning

The action ref is SHA-pinned to `ThreatFlux/github_actions/release@16d779cd569c34743eb6683ca4c0ce105e9ad234` (v0.4.2), as are the `actions/checkout` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
